### PR TITLE
Add support for input type `Uint8Array`

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,12 +33,12 @@ SnappyJS relies on `ArrayBuffer`. All major browsers support it now ([http://can
 
 ### SnappyJS.compress(input)
 
-Compress `input`, which must be type of `ArrayBuffer` or `Buffer`.
+Compress `input`, which must be type of `ArrayBuffer`, `Buffer`, or `Uint8Array`.
 Compressed byte stream is returned, with same type of `input`.
 
 ### SnappyJS.uncompress(compressed)
 
-Uncompress `compressed`, which must be type of `ArrayBuffer` or `Buffer`.
+Uncompress `compressed`, which must be type of `ArrayBuffer`, `Buffer`, or `Uint8Array`.
 Uncompressed byte stream is returned, with same type of `compressed`.
 
 ## Benchmark

--- a/index.js
+++ b/index.js
@@ -35,6 +35,10 @@ function isNode () {
 
 var is_node = isNode()
 
+function isUint8Array (object) {
+  return object instanceof Uint8Array && (!is_node || !Buffer.isBuffer(object))
+}
+
 function isArrayBuffer (object) {
   return object instanceof ArrayBuffer
 }
@@ -49,12 +53,17 @@ function isBuffer (object) {
 var SnappyDecompressor = require('./snappy_decompressor').SnappyDecompressor
 var SnappyCompressor = require('./snappy_compressor').SnappyCompressor
 
+var TYPE_ERROR_MSG = 'Argument compressed must be type of ArrayBuffer, Buffer, or Uint8Array'
+
 function uncompress (compressed) {
-  if (!isArrayBuffer(compressed) && !isBuffer(compressed)) {
-    throw new TypeError('Argument compressed must be type of ArrayBuffer or Buffer')
+  if (!isUint8Array(compressed) && !isArrayBuffer(compressed) && !isBuffer(compressed)) {
+    throw new TypeError(TYPE_ERROR_MSG)
   }
+  var uint8_mode = false
   var array_buffer_mode = false
-  if (isArrayBuffer(compressed)) {
+  if (isUint8Array(compressed)) {
+    uint8_mode = true
+  } else if (isArrayBuffer(compressed)) {
     array_buffer_mode = true
     compressed = new Uint8Array(compressed)
   }
@@ -64,7 +73,12 @@ function uncompress (compressed) {
     throw new Error('Invalid Snappy bitstream')
   }
   var uncompressed, uncompressed_view
-  if (array_buffer_mode) {
+  if (uint8_mode) {
+    uncompressed = new Uint8Array(length)
+    if (!decompressor.uncompressToBuffer(uncompressed)) {
+      throw new Error('Invalid Snappy bitstream')
+    }
+  } else if (array_buffer_mode) {
     uncompressed = new ArrayBuffer(length)
     uncompressed_view = new Uint8Array(uncompressed)
     if (!decompressor.uncompressToBuffer(uncompressed_view)) {
@@ -80,11 +94,14 @@ function uncompress (compressed) {
 }
 
 function compress (uncompressed) {
-  if (!isArrayBuffer(uncompressed) && !isBuffer(uncompressed)) {
-    throw new TypeError('Argument uncompressed must be type of ArrayBuffer or Buffer')
+  if (!isUint8Array(uncompressed) && !isArrayBuffer(uncompressed) && !isBuffer(uncompressed)) {
+    throw new TypeError(TYPE_ERROR_MSG)
   }
+  var uint8_mode = false
   var array_buffer_mode = false
-  if (isArrayBuffer(uncompressed)) {
+  if (isUint8Array(compressed)) {
+    uint8_mode = true
+  } else if (isArrayBuffer(uncompressed)) {
     array_buffer_mode = true
     uncompressed = new Uint8Array(uncompressed)
   }
@@ -92,7 +109,10 @@ function compress (uncompressed) {
   var max_length = compressor.maxCompressedLength()
   var compressed, compressed_view
   var length
-  if (array_buffer_mode) {
+  if (uint8_mode) {
+    compressed = new Uint8Array(max_length)
+    length = compressor.compressToBuffer(compressed)
+  } else if (array_buffer_mode) {
     compressed = new ArrayBuffer(max_length)
     compressed_view = new Uint8Array(compressed)
     length = compressor.compressToBuffer(compressed_view)

--- a/test.js
+++ b/test.js
@@ -30,6 +30,10 @@ var snappyjs = require('./index')
 var fs = require('fs')
 var input_string = fs.readFileSync('snappy_compressor.js', 'utf8')
 
+function bufferToUint8Array (buffer) {
+  return new Uint8Array(buffer)
+}
+
 function bufferToArrayBuffer (buffer) {
   var array_buffer = new ArrayBuffer(buffer.length)
   var view = new Uint8Array(array_buffer)
@@ -38,6 +42,15 @@ function bufferToArrayBuffer (buffer) {
     view[i] = buffer[i]
   }
   return array_buffer
+}
+
+function uint8ArrayToBuffer (uint8Array) {
+  var buffer = new Buffer(uint8Array.length)
+  var i
+  for (i = 0; i < uint8Array.length; i++) {
+    buffer[i] = uint8Array[i]
+  }
+  return buffer
 }
 
 function arrayBufferToBuffer (array_buffer) {
@@ -50,6 +63,16 @@ function arrayBufferToBuffer (array_buffer) {
   return buffer
 }
 
+function stringToUint8Array (source) {
+  var array_buffer = new ArrayBuffer(source.length * 2)
+  var view = new Uint16Array(array_buffer)
+  var i
+  for (i = 0; i < source.length; i++) {
+    view[i] = source.charCodeAt(i)
+  }
+  return new Uint8Array(array_buffer)
+}
+
 function stringToArrayBuffer (source) {
   var array_buffer = new ArrayBuffer(source.length * 2)
   var view = new Uint16Array(array_buffer)
@@ -58,6 +81,16 @@ function stringToArrayBuffer (source) {
     view[i] = source.charCodeAt(i)
   }
   return array_buffer
+}
+
+function uint8ArrayToString (uint8Array) {
+  var view = new Uint16Array(uint8Array.buffer)
+  var result = ''
+  var i
+  for (i = 0; i < view.length; i++) {
+    result += String.fromCharCode(view[i])
+  }
+  return result
 }
 
 function arrayBufferToString (array_buffer) {
@@ -80,6 +113,16 @@ function randomString (length) {
   return result
 }
 
+test('compress() normal text using Uint8Array', function (t) {
+  var compressed = snappyjs.compress(stringToUint8Array(input_string))
+  compressed = arrayBufferToBuffer(compressed)
+  t.equal(snappy.isValidCompressedSync(compressed), true)
+  var uncompressed = snappy.uncompressSync(compressed)
+  var uncompressed_string = arrayBufferToString(bufferToArrayBuffer(uncompressed))
+  t.equal(uncompressed_string, input_string)
+  t.end()
+})
+
 test('compress() normal text using ArrayBuffer', function (t) {
   var compressed = snappyjs.compress(stringToArrayBuffer(input_string))
   compressed = arrayBufferToBuffer(compressed)
@@ -95,6 +138,16 @@ test('compress() normal text using Buffer', function (t) {
   t.equal(snappy.isValidCompressedSync(compressed), true)
   var uncompressed = snappy.uncompressSync(compressed)
   var uncompressed_string = arrayBufferToString(bufferToArrayBuffer(uncompressed))
+  t.equal(uncompressed_string, input_string)
+  t.end()
+})
+
+test('uncompress() normal text using Uint8Array', function (t) {
+  var compressed = snappy.compressSync(arrayBufferToBuffer(stringToArrayBuffer(input_string)))
+  t.equal(snappy.isValidCompressedSync(compressed), true)
+  compressed = bufferToUint8Array(compressed)
+  var uncompressed = snappyjs.uncompress(compressed)
+  var uncompressed_string = uint8ArrayToString(uncompressed)
   t.equal(uncompressed_string, input_string)
   t.end()
 })
@@ -115,6 +168,17 @@ test('uncompress() normal text using Buffer', function (t) {
   var uncompressed = snappyjs.uncompress(compressed)
   var uncompressed_string = arrayBufferToString(bufferToArrayBuffer(uncompressed))
   t.equal(uncompressed_string, input_string)
+  t.end()
+})
+
+test('compress() random string of length 100000 using Uint8Array', function (t) {
+  var random_string = randomString(100000)
+  var compressed = snappyjs.compress(stringToUint8Array(random_string))
+  compressed = uint8ArrayToBuffer(compressed)
+  t.equal(snappy.isValidCompressedSync(compressed), true)
+  var uncompressed = snappy.uncompressSync(compressed)
+  var uncompressed_string = arrayBufferToString(bufferToArrayBuffer(uncompressed))
+  t.equal(uncompressed_string, random_string)
   t.end()
 })
 
@@ -139,6 +203,17 @@ test('compress() random string of length 100000 using Buffer', function (t) {
   t.end()
 })
 
+test('compress() random string of length 100 using Uint8Array', function (t) {
+  var random_string = randomString(100)
+  var compressed = snappyjs.compress(stringToUint8Array(random_string))
+  compressed = uint8ArrayToBuffer(compressed)
+  t.equal(snappy.isValidCompressedSync(compressed), true)
+  var uncompressed = snappy.uncompressSync(compressed)
+  var uncompressed_string = arrayBufferToString(bufferToArrayBuffer(uncompressed))
+  t.equal(uncompressed_string, random_string)
+  t.end()
+})
+
 test('compress() random string of length 100 using ArrayBuffer', function (t) {
   var random_string = randomString(100)
   var compressed = snappyjs.compress(stringToArrayBuffer(random_string))
@@ -156,6 +231,17 @@ test('compress() random string of length 100 using Buffer', function (t) {
   t.equal(snappy.isValidCompressedSync(compressed), true)
   var uncompressed = snappy.uncompressSync(compressed)
   var uncompressed_string = arrayBufferToString(bufferToArrayBuffer(uncompressed))
+  t.equal(uncompressed_string, random_string)
+  t.end()
+})
+
+test('uncompress() random string of length 100000 using Uint8Array', function (t) {
+  var random_string = randomString(100000)
+  var compressed = snappy.compressSync(arrayBufferToBuffer(stringToArrayBuffer(random_string)))
+  t.equal(snappy.isValidCompressedSync(compressed), true)
+  compressed = bufferToUint8Array(compressed)
+  var uncompressed = snappyjs.uncompress(compressed)
+  var uncompressed_string = uint8ArrayToString(uncompressed)
   t.equal(uncompressed_string, random_string)
   t.end()
 })


### PR DESCRIPTION
Currently, if the input type is `Uint8Array`, one needs to convert, or
one needs to leave the input unconverted, depending on the platform.

One particular problem is that in Node, `input instanceof Uint8Array` is
`true` both when `input` is of type `Uint8Array` and `Buffer`, but those
two still need to be treated differently.

With this change, users don't have to bother with detecting the
platform and converting the input anymore when
`input instanceof Uint8Array === true`.