### PR TITLE
fix uint8array compression bug

### DIFF
--- a/index.js
+++ b/index.js
@@ -99,7 +99,7 @@ function compress (uncompressed) {
   }
   var uint8_mode = false
   var array_buffer_mode = false
-  if (isUint8Array(compressed)) {
+  if (isUint8Array(uncompressed)) {
     uint8_mode = true
   } else if (isArrayBuffer(uncompressed)) {
     array_buffer_mode = true


### PR DESCRIPTION
There is a bug in the pull request in https://github.com/zhipeng-jia/snappyjs/pull/1 that makes `Uint8Array` compression completely fail in the browser. Trying to compress `Uint8Array` falls through to the `Buffer` case and `Buffer` is only defined in node, so it throws. This fixes the bug and lets `Uint8Array` compression succeed and return the correct type.