### PR TITLE
uncompress function: add maxLength param

### DIFF
--- a/index.js
+++ b/index.js
@@ -53,7 +53,7 @@ var SnappyCompressor = require('./snappy_compressor').SnappyCompressor
 
 var TYPE_ERROR_MSG = 'Argument compressed must be type of ArrayBuffer, Buffer, or Uint8Array'
 
-function uncompress (compressed) {
+function uncompress (compressed, maxLength) {
   if (!isUint8Array(compressed) && !isArrayBuffer(compressed) && !isBuffer(compressed)) {
     throw new TypeError(TYPE_ERROR_MSG)
   }
@@ -69,6 +69,9 @@ function uncompress (compressed) {
   var length = decompressor.readUncompressedLength()
   if (length === -1) {
     throw new Error('Invalid Snappy bitstream')
+  }
+  if (length > maxLength) {
+    throw new Error(`The uncompressed length of ${length} is too big, expect at most ${maxLength}`)
   }
   var uncompressed, uncompressedView
   if (uint8Mode) {

--- a/test.js
+++ b/test.js
@@ -266,3 +266,13 @@ test('uncompress() random string of length 100000 using Buffer', function (t) {
   t.equal(uncompressedString, randomInputString)
   t.end()
 })
+
+test('uncompress() maxLength', function (t) {
+  var randomInputString = randomString(100000)
+  var compressed = snappy.compressSync(arrayBufferToBuffer(stringToArrayBuffer(randomInputString)))
+  t.equal(snappy.isValidCompressedSync(compressed), true)
+  compressed = bufferToUint8Array(compressed)
+  t.throws(function () { snappyjs.uncompress(compressed, 99999) }, new Error('The uncompressed length of 200000 is too big, expect at most 99999'))//
+
+  t.end()
+})


### PR DESCRIPTION
**Motivation**
It'd be great if we can check the uncompressed length is too big before the actual uncompression

**Description**
- Add `maxLength` param
- This is not a breaking change because if it's undefined, the new `if` condition will always be `false`